### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/papa89q/5c772465-0d7c-4026-9b0f-483660f1d11b/3e04a2fb-02f5-4cc8-b330-568f0aabcce8/_apis/work/boardbadge/3a9b6b0a-f580-45ee-a2b9-63a6fee3b54c)](https://dev.azure.com/papa89q/5c772465-0d7c-4026-9b0f-483660f1d11b/_boards/board/t/3e04a2fb-02f5-4cc8-b330-568f0aabcce8/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/papa89q/5c772465-0d7c-4026-9b0f-483660f1d11b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.